### PR TITLE
Update parrots source URLs

### DIFF
--- a/src/versionControl.ts
+++ b/src/versionControl.ts
@@ -17,11 +17,11 @@ export class VersionControl {
   /**
    * Url to get a list of parrots from.
    */
-  private parrotsUrl: string = 'https://raw.githubusercontent.com/jmhobbs/cultofthepartyparrot.com/master/parrots.json';
+  private parrotsUrl: string = 'https://cultofthepartyparrot.com/parrots.json';
   /**
    * Base url for the parrots images.
    */
-  private parrotBaseUrl: string = 'https://raw.githubusercontent.com/jmhobbs/cultofthepartyparrot.com/master/parrots/';
+  private parrotBaseUrl: string = 'https://cultofthepartyparrot.com/parrots/';
   /**
    * Reference to the cage.
    */


### PR DESCRIPTION
For #1 

However, there is a problem with the yaml to json conversion where the unicode emoji fields result in null, i.e.
```
- gif: pizzaparrot.gif
  name: ! "\U0001F355 Parrot"
- gif: hamburgerparrot.gif
  name: ! "\U0001F354 Parrot"
- gif: bananaparrot.gif
  name: ! "\U0001F34C Parrot"
```

becomes

```
  {
    "gif": "pizzaparrot.gif",
    "name": null
  },
  {
    "gif": "hamburgerparrot.gif",
    "name": null
  },
  {
    "gif": "bananaparrot.gif",
    "name": null
  },
```

Which throws an error when `toLowerCase` is called on it.  Looking at that now, but I'd hold this for merge at the moment.